### PR TITLE
Sprintreview changes

### DIFF
--- a/my-app/src/lib/atoms/question-option.svelte
+++ b/my-app/src/lib/atoms/question-option.svelte
@@ -17,7 +17,7 @@
 
   label {
     border: .1em solid var(--b-z);
-    border-radius: 1em;
+    border-radius: 15px;
     cursor: pointer;
     font-size: 1.25em;
     overflow: hidden;

--- a/my-app/static/css/global.css
+++ b/my-app/static/css/global.css
@@ -24,6 +24,12 @@
   }
 
   @font-face {
+    font-family: Calvino;
+    src: url(../font/calvino-trial/Calvino-Grande-Bold-trial.ttf);
+    font-weight: 900;
+  }
+
+  @font-face {
     font-family: Figtree;
     src: url(../font/figtree/Figtree-Regular.ttf);
     font-weight: 200;


### PR DESCRIPTION
> fixes [#90](https://github.com/fdnd-agency/drop-and-heal/issues/90) and fixes [#91](https://github.com/fdnd-agency/drop-and-heal/issues/91)

# PR borderradius consistent and fontweight heading

## How has this been tested?
- [ ] usertest
- [ ] browser test
- [ ] device test
- [ ] screenreader test
- [ ] tab test
- [ ] responsive design test
- [ ] performance test
- [ ] accessibility test

## How to review

- Bekijk css van componenten
- Bekijk global css 

## Borderradius consistent

Bij de vragenlijst op de form pagina moet de borderradius aangepast worden, zodat het meer consistent uitziet.

## Before

<img width="100%" alt="Scherm­afbeelding 2024-12-18 om 10 07 17" src="https://github.com/user-attachments/assets/07bafa0c-fd7e-4d69-99d9-d5ce13b7bc06" />

## After

<img width="100%" alt="Scherm­afbeelding 2024-12-18 om 10 08 22" src="https://github.com/user-attachments/assets/f15b8c65-dd5a-498d-9044-16db29c8cf95" />

## Code

```
  label {
    border-radius: 15px;
  }
```

## Fontweight heading

De font van heading op de form page moet worden aangepast naar bold.

## Before

<img width="100%" alt="Scherm­afbeelding 2024-12-18 om 10 12 45" src="https://github.com/user-attachments/assets/db4aaa43-65fe-4d7b-a38d-e6c010263afd" />

## After

<img width="100%" alt="Scherm­afbeelding 2024-12-18 om 10 12 58" src="https://github.com/user-attachments/assets/b9b9811e-4aeb-4673-99b4-d6b024d1d1d0" />

## Code

```
  @font-face {
    font-family: Calvino;
    src: url(../font/calvino-trial/Calvino-Grande-Bold-trial.ttf);
    font-weight: 900;
  }
```