### PR TITLE
Issue #125 Nav Buttons opgelost 

### DIFF
--- a/my-app/src/lib/NavButtons.svelte
+++ b/my-app/src/lib/NavButtons.svelte
@@ -8,16 +8,12 @@
 </script>
 
 <div class="nav-buttons">
-    <button style="border: 1px solid {borderColor}">
-        <a href={leftLink} class="nav-link">
-            <ArrowL />
-        </a>
-    </button>
-    <button style="border: 1px solid {borderColor}">
-        <a href={rightLink} class="nav-link">
-            <ArrowR />
-        </a>
-    </button>
+    <a href={leftLink} class="nav-link" style="border: 1px solid {borderColor}">
+        <ArrowL />
+    </a>
+    <a href={rightLink} class="nav-link" style="border: 1px solid {borderColor}">
+        <ArrowR />
+    </a>
 </div>
 
 <style>
@@ -30,31 +26,31 @@
         margin-bottom: 0.5rem; 
     }
 
-    .nav-buttons button {
+    .nav-buttons a {
         background: none;
         border-radius: 50%;
-        width: 50px; 
-        height: 50px; 
+        width: 50px;
+        height: 50px;
         display: flex;
         justify-content: center;
         align-items: center;
         cursor: pointer;
         transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+        text-decoration: none;
     }
 
-    .nav-buttons button:hover {
+    .nav-buttons a:hover {
         background-color: rgba(255, 255, 255, 0.1); 
         border-color: rgba(255, 255, 255, 1); 
         color: rgba(255, 255, 255, 1); 
     }
 
-    .nav-buttons button:disabled {
+    .nav-buttons a:disabled {
         opacity: 0.5;
         cursor: not-allowed;
     }
 
     .nav-link {
-        text-decoration: none;
         color: inherit;
         display: flex;
         justify-content: center;


### PR DESCRIPTION
### What is changed?
Opgelost issue #125 met betrekking op de toegankelijkheid van de code. Het probleem was dat een <button> element heeft daarin een <a> element, wat niet semantisch correct is, ze zouden niet genest moeten zijn.
Ik heb <button> verwijderd en alleen <a> elementen gebruikt voor de navigatie. 

### How to review

Bekijk /lib/NavButtons.svelte.

### How has this been tested?

Met tab-test. De navigatie link wordt nu inderdaad meteen geselecteerd ipv dat er eerst button wordt geselecteerd en daarna nog de link.  

<img width="360" alt="image" src="https://github.com/user-attachments/assets/2693f527-a8b9-4376-9d9b-7ad9877e72d7" />

### Code 

```
<div class="nav-buttons">
    <a href={leftLink} class="nav-link" style="border: 1px solid {borderColor}">
        <ArrowL />
    </a>
    <a href={rightLink} class="nav-link" style="border: 1px solid {borderColor}">
        <ArrowR />
    </a>
</div>
```
